### PR TITLE
Prevent a logged-off user's local observations from being edited by the current user

### DIFF
--- a/lib/screens/observations_screen.dart
+++ b/lib/screens/observations_screen.dart
@@ -103,17 +103,22 @@ class ObservationsPageState extends State<ObservationsPage> {
       valueListenable: Hive.box<LocalObservation>(FirebaseObservationsService.OBSERVATIONS_COLLECTION_NAME).listenable(),
       builder: (context, box, widget2){
 
+        final user = Provider.of<AppUser?>(context);
+        final userId = user?.uid ?? "";
+
         //Get all locally saved observations
         Map<dynamic, dynamic> raw = box.toMap();
         List list = raw.values.toList();
         localObservations = <Observation>[];
         for (var element in list) {
           LocalObservation localObservation = element;
-          var observation = toObservation(localObservation, buttonText: translations.viewObservation);
-          localObservations.add(observation);
-        }
 
-        var user = Provider.of<AppUser?>(context);
+          //Only load observations for the current user or observations that don't have an ownerId because they were made when the user wasn't logged in
+          if (localObservation.observerUid == userId || localObservation.observerUid.isEmpty) {
+            var observation = toObservation(localObservation, buttonText: translations.viewObservation);
+            localObservations.add(observation);
+          }
+        }
 
         var needUploaded = user != null && localObservationsNeedUploaded();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: "Patrol, track, and log pikas"
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 3.0.4+304
+version: 3.0.5+305
 
 environment:
   sdk: '>=3.3.0-71.0.dev <4.0.0'


### PR DESCRIPTION
Only show local observations for the current user. This ensures that only the current user can see and even try to update the local observations. Without this, a device can have multiple accounts, with only one being logged into, and yet show observations for accounts that aren't logged into. This causes permission denials when an observation is edited for an account that isn't logged in - which makes sense